### PR TITLE
fix dependency for Announcements controller

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    starburst (1.0.2)
+    starburst (1.0.3)
       rails (>= 3.0)
 
 GEM
@@ -60,7 +60,7 @@ GEM
     mime-types (2.4.3)
     mini_portile (0.6.0)
     minitest (5.4.3)
-    multi_json (1.10.1)
+    multi_json (1.11.0)
     nokogiri (1.6.3.1)
       mini_portile (= 0.6.0)
     rack (1.5.2)

--- a/app/controllers/starburst/announcements_controller.rb
+++ b/app/controllers/starburst/announcements_controller.rb
@@ -1,3 +1,5 @@
+require_dependency 'starburst/application_controller'
+
 module Starburst
 	class AnnouncementsController < ApplicationController
 		def mark_as_read


### PR DESCRIPTION
Previously Rails autoload mechanism (in dev env) did know about  `starburst/application_controller` presence, so `Starburst::AnnouncementsController` inherited from `::ApplicationController`, not `Starburst::ApplicationController`, that causes errors due to authentication, etc.

 `require_dependency` directive fixes this issue.