### PR TITLE
Add partial with bootstrap panel markup

### DIFF
--- a/app/assets/stylesheets/starburst/application.css
+++ b/app/assets/stylesheets/starburst/application.css
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+.inline {
+  display: inline;
+}

--- a/app/views/announcements/starburst/_announcement_bootstrap_panel.erb
+++ b/app/views/announcements/starburst/_announcement_bootstrap_panel.erb
@@ -1,0 +1,17 @@
+<% if current_announcement %>
+	<%= form_tag starburst.mark_as_read_path(current_announcement.id), :remote => true do %>
+		<div class="panel panel-info" id="starburst-announcement" role="alert">
+			<div class="panel-heading text-center">
+				<span class="glyphicon glyphicon-bullhorn pull-left"></span>
+				<h3 class="panel-title inline"><%= t(:announcement) %></h3>
+				<button name="commit" type="submit" class="close" id="starburst-close">
+					<span aria-hidden="true">&times;</span>
+					<span class="sr-only"><%= t(:close) %></span>
+				</button>
+			</div>
+			<div class="panel-body">
+				<p><%= current_announcement.body.html_safe %></p>
+			</div>
+		</div>
+	<% end %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,3 @@
+en:
+  announcement: Announcement
+  close: Close


### PR DESCRIPTION
This change builds on the existing partial that using Bootstrap compatible markup, only using a panel instead of an alert. A panel would be useful for anyone who may way to insert the announcement somewhere in the UI with a little more screen real estate, and might have room for a panel. 

I think the panel heading provides a good spot for an icon, a title, and the close button that dismisses the announcement. I could later modify this to include the title of the announcement as the title of the panel as well, but thought just simply *Announcement* would be good for the panel title for now.